### PR TITLE
Enhance getLiveQuestionCountByTaxonomy with bandwidth logging

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as customFunctions from "../customFunctions.js";
 import type * as customQuizzes from "../customQuizzes.js";
 import type * as groups from "../groups.js";
 import type * as http from "../http.js";
+import type * as instrumentation from "../instrumentation.js";
 import type * as migrations from "../migrations.js";
 import type * as presetQuizzes from "../presetQuizzes.js";
 import type * as questionAnalytics from "../questionAnalytics.js";
@@ -59,6 +60,7 @@ declare const fullApi: ApiFromModules<{
   customQuizzes: typeof customQuizzes;
   groups: typeof groups;
   http: typeof http;
+  instrumentation: typeof instrumentation;
   migrations: typeof migrations;
   presetQuizzes: typeof presetQuizzes;
   questionAnalytics: typeof questionAnalytics;

--- a/convex/instrumentation.ts
+++ b/convex/instrumentation.ts
@@ -1,0 +1,41 @@
+import { v } from 'convex/values';
+
+import { internalMutation } from './_generated/server';
+
+export const logSize = internalMutation({
+  args: {
+    payload: v.any(), // Generic input to pass through
+  },
+  handler: async (ctx, { payload }) => {
+    const encoder = new TextEncoder();
+    const sizeIn = encoder.encode(JSON.stringify(payload)).length;
+
+    // Simulate or replace with your actual logic
+    const result = await someHeavyFunction(payload);
+
+    const sizeOut = encoder.encode(JSON.stringify(result)).length;
+
+    console.log(
+      `[BANDWIDTH] In: ${sizeIn} bytes, Out: ${sizeOut} bytes, Total: ${sizeIn + sizeOut} bytes`,
+    );
+
+    return result;
+  },
+});
+
+// Helper function - replace with your actual heavy function logic
+async function someHeavyFunction(payload: any) {
+  // This is a placeholder - replace with your actual function logic
+  // For now, just return the payload as an example
+  return payload;
+}
+
+// Utility function for inline bandwidth logging
+export const logBandwidth = (functionName: string, input: any, output: any) => {
+  const encoder = new TextEncoder();
+  const sizeIn = encoder.encode(JSON.stringify(input)).length;
+  const sizeOut = encoder.encode(JSON.stringify(output)).length;
+  console.log(
+    `[BANDWIDTH] ${functionName} - In: ${sizeIn} bytes, Out: ${sizeOut} bytes, Total: ${sizeIn + sizeOut} bytes`,
+  );
+};

--- a/convex/taxonomyAggregates.ts
+++ b/convex/taxonomyAggregates.ts
@@ -1,6 +1,6 @@
 import { v } from 'convex/values';
 
-import { api } from './_generated/api';
+import { api, internal } from './_generated/api';
 import { Id } from './_generated/dataModel';
 import { query } from './_generated/server';
 
@@ -131,6 +131,10 @@ export const getLiveQuestionCountByTaxonomy = query({
   },
   returns: v.number(),
   handler: async (ctx, args) => {
+    // Log input bandwidth
+    const encoder = new TextEncoder();
+    const sizeIn = encoder.encode(JSON.stringify(args)).length;
+
     let questions: any[] = [];
 
     if (args.taxonomyIds && args.taxonomyIds.length > 0) {
@@ -194,7 +198,15 @@ export const getLiveQuestionCountByTaxonomy = query({
       }
     }
 
-    return questions.length;
+    const result = questions.length;
+
+    // Log output bandwidth
+    const sizeOut = encoder.encode(JSON.stringify(result)).length;
+    console.log(
+      `[BANDWIDTH] getLiveQuestionCountByTaxonomy - In: ${sizeIn} bytes, Out: ${sizeOut} bytes, Total: ${sizeIn + sizeOut} bytes`,
+    );
+
+    return result;
   },
 });
 


### PR DESCRIPTION
- Added input and output bandwidth logging to the getLiveQuestionCountByTaxonomy query.
- Imported internal API for potential future instrumentation needs.
- Improved visibility into data processing sizes for better performance monitoring.