### PR TITLE
Add optional `taxonomyPathIds` field to schema and migration process

### DIFF
--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -147,6 +147,7 @@ export const processBatch = internalMutation({
           if ('TaxThemeId' in doc) fieldsToRemove.push('TaxThemeId');
           if ('TaxSubthemeId' in doc) fieldsToRemove.push('TaxSubthemeId');
           if ('TaxGroupId' in doc) fieldsToRemove.push('TaxGroupId');
+          if ('taxonomyPathIds' in doc) fieldsToRemove.push('taxonomyPathIds');
 
           break;
         }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -62,6 +62,7 @@ export default defineSchema({
     TaxThemeId: v.optional(v.string()),
     TaxSubthemeId: v.optional(v.string()),
     TaxGroupId: v.optional(v.string()),
+    taxonomyPathIds: v.optional(v.array(v.string())),
   })
     .index('by_title', ['normalizedTitle'])
     .index('by_theme', ['themeId'])


### PR DESCRIPTION
- Introduced `taxonomyPathIds` as an optional field in the schema for improved legacy taxonomy support.
- Updated the migration process to remove `taxonomyPathIds` from documents as part of the cleanup operations.