### PR TITLE
Refactor question display and profile page styles

### DIFF
--- a/src/app/(dashboard)/admin/gerenciar-questoes/[questionId]/_components/question-display.tsx
+++ b/src/app/(dashboard)/admin/gerenciar-questoes/[questionId]/_components/question-display.tsx
@@ -34,9 +34,7 @@ export function QuestionDisplay({
           </div>
 
           <div>
-            <h2 className="my-4 mb-4 border-t pt-2 font-semibold">
-              Alternativas:
-            </h2>
+            
             <div className="mt-4 space-y-2">
               {question.alternatives?.map(
                 (alternative: string, index: number) => (

--- a/src/app/(dashboard)/perfil/page.tsx
+++ b/src/app/(dashboard)/perfil/page.tsx
@@ -87,12 +87,12 @@ export default function ProfilePage() {
         {
           name: 'Respondidas',
           value: totalAnswered,
-          color: '#22c55e', // green
+          color: '#2388e2', // blue
         },
         {
           name: 'Não Respondidas',
           value: totalQuestions - totalAnswered,
-          color: '#ef4444', // red
+          color: '#f7f9fd', // gray
         },
       ]
     : [];

--- a/src/components/quiz/QuizAlternatives.tsx
+++ b/src/components/quiz/QuizAlternatives.tsx
@@ -126,7 +126,6 @@ export default function QuizAlternatives({
 
   return (
     <div>
-      <h2 className="my-2 border-t pt-4 font-semibold">Alternativas:</h2>
       <div className="mt-4 space-y-2">
         {alternatives.map((alternative, i) => {
           // Determine the appropriate styling for each alternative


### PR DESCRIPTION
- Removed unnecessary heading for alternatives in QuestionDisplay component to streamline UI.
- Updated color scheme for answered and unanswered questions in ProfilePage for improved visual consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the “Alternativas:” section header from question and quiz views to streamline the interface while keeping alternative options and correct-answer highlighting unchanged.
  * Updated Profile progress chart colors: “Respondidas” is now blue (#2388e2) and “Não Respondidas” is now gray (#f7f9fd) for improved visual clarity and consistency.
  * Minor spacing/DOM adjustments resulting from header removal; no changes to logic, data, or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->