### PR TITLE
Refactor onboarding display logic in dashboard layout

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -25,11 +25,15 @@ export default function Layout({
   useEffect(() => {
     const hasCompletedOnboarding = user?.onboardingCompleted;
     
-    if (isAuthenticated && !hasCompletedOnboarding) {
+    // Only show onboarding if explicitly marked as false (not undefined or loading)
+    if (isAuthenticated && user && hasCompletedOnboarding === false) {
       // Small delay to ensure sidebar is rendered
       setTimeout(() => setShowOnboarding(true), 500);
+    } else {
+      // Hide onboarding in all other cases
+      setShowOnboarding(false);
     }
-  }, [user?.onboardingCompleted, isAuthenticated]);
+  }, [user?.onboardingCompleted, isAuthenticated, user]);
 
   // Redirect to sign-in if not authenticated using Next.js navigation
   useEffect(() => {

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -24,16 +24,24 @@ export default function Layout({
   // Check if user should see onboarding (simplified without URL params)
   useEffect(() => {
     const hasCompletedOnboarding = user?.onboardingCompleted;
+    let timerId: NodeJS.Timeout | undefined;
     
     // Only show onboarding if explicitly marked as false (not undefined or loading)
     if (isAuthenticated && user && hasCompletedOnboarding === false) {
       // Small delay to ensure sidebar is rendered
-      setTimeout(() => setShowOnboarding(true), 500);
+      timerId = setTimeout(() => setShowOnboarding(true), 500);
     } else {
       // Hide onboarding in all other cases
       setShowOnboarding(false);
     }
-  }, [user?.onboardingCompleted, isAuthenticated, user]);
+    
+    // Cleanup: cancel pending timer when effect re-runs or component unmounts
+    return () => {
+      if (timerId) {
+        clearTimeout(timerId);
+      }
+    };
+  }, [user?.onboardingCompleted, isAuthenticated]);
 
   // Redirect to sign-in if not authenticated using Next.js navigation
   useEffect(() => {


### PR DESCRIPTION
- Updated onboarding visibility conditions to only show when explicitly marked as false, improving user experience.
- Added logic to hide onboarding in all other cases, ensuring clarity in user onboarding flow.
- Adjusted dependencies in useEffect to include the user object for more accurate state management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Onboarding now appears only for signed-in users who explicitly haven’t completed it, preventing accidental prompts.
  - Hides onboarding in all other cases for a cleaner, less intrusive experience.
  - Adds a brief, managed 500ms delay before showing onboarding and ensures the delay is cleared on navigation/unmount to avoid flicker.

- Chores
  - Improved onboarding display logic for more reliable behavior across auth and profile states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->